### PR TITLE
Multi-ZK setup Fixed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,12 +5,7 @@
 # in the same node.
 if [ ! -f /kafka/config/server.properties ]; then
 	# Create a ZK connection string for the servers and the root.
-	ZOOKEEPER_CONNECT=()
-	IFS=\, read -a servers <<< "${ZOOKEEPER_SERVERS:=zookeeper:2181}"
-	for server in "${servers[@]}"; do 
-		ZOOKEEPER_CONNECT+=("$server${ZOOKEEPER_ROOT:=/kafka}")
-	done
-	ZOOKEEPER_CONNECT=$(IFS=, ; echo "${ZOOKEEPER_CONNECT[*]}")
+	ZOOKEEPER_CONNECT=$ZOOKEEPER_SERVERS${ZOOKEEPER_ROOT:=/kafka}
 
 	echo "Using ZK at ${ZOOKEEPER_CONNECT}"
 


### PR DESCRIPTION
Great image, Kafka seems to require a list of zk servers in the following format:
zookeeper.connect=foo:1234,bar:1234,bam:1234/zkroot

Changed entrypoint script to append ZOOKEEPER_CONNECT with ZOOKEEPER_ROOT once only

Tested on k8 with 3 Kafka pods and 3 Zookeeper (V3.4.6) pods (each zk with a different ip), with and without specifying zookeeper_root in k8 config file.
Kafka brokers recconect to another zk pod fine.
